### PR TITLE
Instala o zip e o sdk python da aws (boto3) para conseguir executar o…

### DIFF
--- a/ruby2/Dockerfile
+++ b/ruby2/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.3.2
 
 #Dependencies
 RUN apt-get update && \
-    apt-get install -y build-essential python-dev ruby-full --no-install-recommends && \
+    apt-get install -y build-essential python-dev ruby-full zip --no-install-recommends && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN \
   curl -O https://bootstrap.pypa.io/get-pip.py && \
   python get-pip.py && \
-  pip install --upgrade awsebcli awscli && \
+  pip install --upgrade awsebcli awscli boto3==1.3.0 && \
   aws configure set preview.cloudfront true && \
   rm -rf get-pip.py
 


### PR DESCRIPTION
Instala o zip e o sdk python da aws (boto3) para conseguir executar o script de deploy do beanstalk.